### PR TITLE
No JSON.parse(response.body) in specs

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -20,3 +20,9 @@ Discourse/TimeEqMatcher:
   Patterns:
   - _spec.rb
   - "(?:^|/)spec/"
+
+Discourse/NoJsonParseResponse:
+  Enabled: true
+  Patterns:
+  - _spec.rb
+  - "(?:^|/)spec/"

--- a/config/default.yml
+++ b/config/default.yml
@@ -1,14 +1,22 @@
 Discourse/NoChdir:
   Enabled: true
 
-Discourse/NoDirectMultisiteManipulation:
-  Enabled: true
-
 Discourse/NoTimeNewWithoutArgs:
   Enabled: true
 
 Discourse/NoUriEscapeEncode:
   Enabled: true
 
+# Specs
+
+Discourse/NoDirectMultisiteManipulation:
+  Enabled: true
+  Patterns:
+  - _spec.rb
+  - "(?:^|/)spec/"
+
 Discourse/TimeEqMatcher:
   Enabled: true
+  Patterns:
+  - _spec.rb
+  - "(?:^|/)spec/"

--- a/lib/rubocop/cop/discourse/no_json_parse_response.rb
+++ b/lib/rubocop/cop/discourse/no_json_parse_response.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Discourse
+      # Use `response.parsed_body` instead of `JSON.parse(response.body)` in specs.
+      #
+      # @example
+      #   # bad
+      #   expect(::JSON.parse(response.body)).to eq({})
+      #
+      #   # good
+      #   expect(response.parsed_body).to eq({})
+      class NoJsonParseResponse < Cop
+        MSG = "Use `response.parsed_body` instead of `JSON.parse(response.body)` in specs."
+
+        def_node_matcher :json_parse_body?, <<-MATCHER
+          (send
+            (const {cbase nil?} :JSON) :parse
+            (send
+              (send nil? :response) :body))
+        MATCHER
+
+          # s(:send,
+          #   s(:const, nil, :JSON), :parse,
+          #   s(:send,
+          #     s(:send, nil, :response), :body))
+
+        def on_send(node)
+          # puts node.inspect
+          return unless json_parse_body?(node)
+
+          add_offense(node, message: MSG)
+        end
+
+        def autocorrect(node)
+          lambda do |corrector|
+            corrector.replace(node.loc.expression, "response.parsed_body")
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/discourse/no_json_parse_response.rb
+++ b/lib/rubocop/cop/discourse/no_json_parse_response.rb
@@ -21,13 +21,7 @@ module RuboCop
               (send nil? :response) :body))
         MATCHER
 
-          # s(:send,
-          #   s(:const, nil, :JSON), :parse,
-          #   s(:send,
-          #     s(:send, nil, :response), :body))
-
         def on_send(node)
-          # puts node.inspect
           return unless json_parse_body?(node)
 
           add_offense(node, message: MSG)


### PR DESCRIPTION
"Use `response.parsed_body` instead of `JSON.parse(response.body)` in specs."