### PR TITLE
FEATURE: Add `NoNokogiriHtmlFragment` cop

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -10,6 +10,9 @@ Discourse/NoTimeNewWithoutArgs:
 Discourse/NoUriEscapeEncode:
   Enabled: true
 
+Discourse/NoNokogiriHtmlFragment:
+  Enabled: true
+
 # Specs
 
 Discourse/NoDirectMultisiteManipulation:

--- a/lib/rubocop/cop/discourse/no_nokogiri_html_fragment.rb
+++ b/lib/rubocop/cop/discourse/no_nokogiri_html_fragment.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Discourse
+      # Do not use Nokogiri::HTML.fragment
+      # Instead use Nokogiri::HTML5.fragment, which is using Nokogumbo parser
+      #
+      # @example
+      #   # bad
+      #   Nokogiri::HTML.fragment("<p>test</p>")
+      #
+      #   # good
+      #   Nokogiri::HTML5.fragment("<p>test</p>")
+      class NoNokogiriHtmlFragment < Cop
+        MSG = "Nokogiri::HTML.fragment is deprecated and should not be used."
+
+        def_node_matcher :using_nokogiri_html_fragment?, <<-MATCHER
+          (send
+            (const
+              (const nil? :Nokogiri) :HTML) :fragment ...)
+        MATCHER
+
+        def on_send(node)
+          return if !using_nokogiri_html_fragment?(node)
+          add_offense(node, message: MSG)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Nokogumbo changes are merged to Discourse https://github.com/discourse/discourse/pull/9577

We should protect codebase to not use Nokogiri::HTML anymore