### PR TITLE
DEV: Remove a retired InvalidPredicateMatcher option

### DIFF
--- a/rubocop-discourse.gemspec
+++ b/rubocop-discourse.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name        = "rubocop-discourse"
-  s.version     = "2.4.0"
+  s.version     = "2.4.1"
   s.summary     = "Custom rubocop cops used by Discourse"
   s.authors     = ["David Taylor"]
   s.license     = "MIT"
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_runtime_dependency "rubocop", ">= 1.1.0"
-  s.add_runtime_dependency "rubocop-rspec", ">= 2.0.0.pre"
+  s.add_runtime_dependency "rubocop-rspec", ">= 2.0.0"
 
   s.add_development_dependency "rake", "~> 13.0"
   s.add_development_dependency "rspec"

--- a/rubocop-rspec.yml
+++ b/rubocop-rspec.yml
@@ -99,9 +99,6 @@ RSpec/InstanceSpy:
 RSpec/InstanceVariable:
   Enabled: false # TODO
 
-RSpec/InvalidPredicateMatcher:
-  Enabled: true
-
 RSpec/ItBehavesLike:
   Enabled: true
 


### PR DESCRIPTION
Updates rubocop-rspec to 2.0.0 an bumps rubocop-discourse to 2.4.1