### PR TITLE
Remove Layout/LineLength from syntax_tree_compat

### DIFF
--- a/rubocop-core.yml
+++ b/rubocop-core.yml
@@ -50,10 +50,3 @@ Lint/ShadowingOuterLocalVariable:
 
 Bundler/OrderedGems:
   Enabled: false
-
-# Enable Layout/LineLength because certain cops that most projects use
-# (e.g. Style/IfUnlessModifier) require Layout/LineLength to be enabled.
-# By leaving it disabled, those rules will mis-fire.
-Layout/LineLength:
-  Enabled: true
-  Max: 240

--- a/rubocop-discourse.gemspec
+++ b/rubocop-discourse.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name        = "rubocop-discourse"
-  s.version     = "3.0.1"
+  s.version     = "3.0.2"
   s.summary     = "Custom rubocop cops used by Discourse"
   s.authors     = ["Discourse Team"]
   s.license     = "MIT"


### PR DESCRIPTION
This is recommended by syntax_tree for compatibility with some `Style/` cops. We don't seem to have any problematic cops enabled, so this is unnecessary and introduces unnecessary work to manually fix long lines. We use syntax_tree to reduce line length **when it can be done automatically**.