### PR TITLE
Disable Layout/LineLength for syntax_tree_compat

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -1,6 +1,3 @@
 inherit_from:
   - ./stree-compat.yml
   - ./rubocop-layout.yml
-
-Layout/LineLength:
-  Enabled: false

--- a/rubocop-core.yml
+++ b/rubocop-core.yml
@@ -50,3 +50,6 @@ Lint/ShadowingOuterLocalVariable:
 
 Bundler/OrderedGems:
   Enabled: false
+
+Layout/LineLength:
+  Enabled: false

--- a/rubocop-discourse.gemspec
+++ b/rubocop-discourse.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name        = "rubocop-discourse"
-  s.version     = "3.0.2"
+  s.version     = "3.0.3"
   s.summary     = "Custom rubocop cops used by Discourse"
   s.authors     = ["Discourse Team"]
   s.license     = "MIT"


### PR DESCRIPTION
1ed27272 intended to remove the LineLength restriction, but the default is enabled to we need to explicitly disable it