### PR TITLE
DEV: Update target ruby version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '2.6'
+          ruby-version: '3.2'
           bundler-cache: true
 
       - name: Rubocop

--- a/config/default.yml
+++ b/config/default.yml
@@ -13,8 +13,8 @@ Discourse/NoURIEscapeEncode:
 Discourse/NoAddReferenceOrAliasesActiveRecordMigration:
   Enabled: true
   Include:
-  - "**/db/migrate/*"
-  - "**/db/post_migrate/*"
+    - '**/db/migrate/*'
+    - '**/db/post_migrate/*'
 
 Discourse/NoNokogiriHtmlFragment:
   Enabled: true
@@ -22,43 +22,43 @@ Discourse/NoNokogiriHtmlFragment:
 Discourse/NoResetColumnInformationInMigrations:
   Enabled: false
   Include:
-  - "**/db/migrate/*"
-  - "**/db/post_migrate/*"
+    - '**/db/migrate/*'
+    - '**/db/post_migrate/*'
 
 # Specs
 
 Discourse/NoDirectMultisiteManipulation:
   Enabled: true
   Patterns:
-  - _spec.rb
-  - "(?:^|/)spec/"
+    - _spec.rb
+    - '(?:^|/)spec/'
 
 Discourse/TimeEqMatcher:
   Enabled: true
   Patterns:
-  - _spec.rb
-  - "(?:^|/)spec/"
+    - _spec.rb
+    - '(?:^|/)spec/'
 
 Discourse/NoJsonParseResponse:
   Enabled: false
   Patterns:
-  - _spec.rb
-  - "(?:^|/)spec/"
+    - _spec.rb
+    - '(?:^|/)spec/'
 
 Discourse/NoMockingJobs:
   Enabled: true
   Patterns:
-  - _spec.rb
-  - "(?:^|/)spec/"
+    - _spec.rb
+    - '(?:^|/)spec/'
 
 Discourse/OnlyTopLevelMultisiteSpecs:
   Enabled: true
   Patterns:
-  - _spec.rb
-  - "(?:^|/)spec/"
+    - _spec.rb
+    - '(?:^|/)spec/'
 
 Discourse/NoMixingMultisiteAndStandardSpecs:
   Enabled: true
   Patterns:
-  - _spec.rb
-  - "(?:^|/)spec/"
+    - _spec.rb
+    - '(?:^|/)spec/'

--- a/rubocop-core.yml
+++ b/rubocop-core.yml
@@ -4,6 +4,9 @@ Security:
 Security/IoMethods:
   Enabled: true
 
+Security/CompoundHash:
+  Enabled: true
+
 # Prefer &&/|| over and/or.
 Style/AndOr:
   Enabled: true
@@ -14,6 +17,7 @@ Style/FrozenStringLiteralComment:
 # Use Ruby >= 1.9 syntax for hashes. Prefer { a: :b } over { :a => :b }.
 Style/HashSyntax:
   Enabled: true
+  EnforcedShorthandSyntax: either
 
 # Defining a method with parameters needs parentheses.
 Style/MethodDefParentheses:

--- a/rubocop-discourse.gemspec
+++ b/rubocop-discourse.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name = "rubocop-discourse"
-  s.version = "3.1.0"
+  s.version = "3.2.0"
   s.summary = "Custom rubocop cops used by Discourse"
   s.authors = ["Discourse Team"]
   s.license = "MIT"

--- a/rubocop-rspec.yml
+++ b/rubocop-rspec.yml
@@ -31,17 +31,17 @@ RSpec/ContextWording:
 RSpec/DescribeClass:
   Enabled: true
   Exclude:
-    - "**/spec/features/**/*"
-    - "**/spec/requests/**/*"
-    - "**/spec/routing/**/*"
-    - "**/spec/system/**/*"
-    - "**/spec/views/**/*"
-    - "**/spec/initializers/**/*"
-    - "**/spec/integration/**/*"
-    - "**/spec/integrity/**/*"
-    - "**/spec/tasks/**/*"
-    - "**/spec/lib/freedom_patches/**/*"
-    - "**/spec/multisite/**/*"
+    - '**/spec/features/**/*'
+    - '**/spec/requests/**/*'
+    - '**/spec/routing/**/*'
+    - '**/spec/system/**/*'
+    - '**/spec/views/**/*'
+    - '**/spec/initializers/**/*'
+    - '**/spec/integration/**/*'
+    - '**/spec/integrity/**/*'
+    - '**/spec/tasks/**/*'
+    - '**/spec/lib/freedom_patches/**/*'
+    - '**/spec/multisite/**/*'
 
 RSpec/DescribeMethod:
   Enabled: true
@@ -213,7 +213,7 @@ RSpec/VoidExpect:
 RSpec/Yield:
   Enabled: true
 
-RSpec/Capybara/CurrentPathExpectation:
+Capybara/CurrentPathExpectation:
   Enabled: true
 
 RSpec/Capybara/FeatureMethods:

--- a/stree-compat.yml
+++ b/stree-compat.yml
@@ -6,16 +6,16 @@ inherit_from:
   - ./rubocop-rspec.yml
 
 AllCops:
-  TargetRubyVersion: 2.6
+  TargetRubyVersion: 3.2
   DisabledByDefault: true
   Exclude:
-    - "db/schema.rb"
-    - "bundle/**/*"
-    - "vendor/**/*"
-    - "**/node_modules/**/*"
-    - "public/**/*"
-    - "plugins/**/gems/**/*"
-    - "plugins/**/vendor/**/*"
+    - 'db/schema.rb'
+    - 'bundle/**/*'
+    - 'vendor/**/*'
+    - '**/node_modules/**/*'
+    - 'public/**/*'
+    - 'plugins/**/gems/**/*'
+    - 'plugins/**/vendor/**/*'
 
 Discourse:
   Enabled: true


### PR DESCRIPTION
Fixes parsing issues with rubocop 1.48.1

Also:
* Enable new security rule (`Security/CompoundHash`)
* Update `Style/HashSyntax` options (`EnforcedShorthandSyntax: either`) so it doesn't spam warnings all over the place after the ruby version syntax change
* And lint yaml (" vs ')