### PR TITLE
DEV: Honor split RuboCop gems

### DIFF
--- a/rubocop-capybara.yml
+++ b/rubocop-capybara.yml
@@ -1,0 +1,5 @@
+require:
+  - rubocop-capybara
+
+Capybara/CurrentPathExpectation:
+  Enabled: true

--- a/rubocop-discourse.gemspec
+++ b/rubocop-discourse.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "rubocop", ">= 1.59.0"
   s.add_runtime_dependency "rubocop-rspec", ">= 2.25.0"
   s.add_runtime_dependency "rubocop-factory_bot", ">= 2.0.0"
-  s.add_runtime_dependency "rubocop-rspec", ">= 2.0.0"
+  s.add_runtime_dependency "rubocop-capybara", ">= 2.0.0"
 
   s.add_development_dependency "rake", "~> 13.1.0"
   s.add_development_dependency "rspec", "~> 3.12.0"

--- a/rubocop-discourse.gemspec
+++ b/rubocop-discourse.gemspec
@@ -13,6 +13,8 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency "rubocop", ">= 1.59.0"
   s.add_runtime_dependency "rubocop-rspec", ">= 2.25.0"
+  s.add_runtime_dependency "rubocop-factory_bot", ">= 2.0.0"
+  s.add_runtime_dependency "rubocop-rspec", ">= 2.0.0"
 
   s.add_development_dependency "rake", "~> 13.1.0"
   s.add_development_dependency "rspec", "~> 3.12.0"

--- a/rubocop-factory_bot.yml
+++ b/rubocop-factory_bot.yml
@@ -1,0 +1,11 @@
+require:
+  - rubocop-factory_bot
+
+FactoryBot/AttributeDefinedStatically:
+  Enabled: true
+
+FactoryBot/CreateList:
+  Enabled: true
+
+FactoryBot/FactoryClassName:
+  Enabled: true

--- a/rubocop-rspec.yml
+++ b/rubocop-rspec.yml
@@ -223,22 +223,7 @@ RSpec/VoidExpect:
 RSpec/Yield:
   Enabled: true
 
-Capybara/CurrentPathExpectation:
-  Enabled: true
-
 RSpec/Capybara/FeatureMethods:
-  Enabled: true
-
-Capybara/VisibilityMatcher:
-  Enabled: true
-
-FactoryBot/AttributeDefinedStatically:
-  Enabled: true
-
-FactoryBot/CreateList:
-  Enabled: true
-
-FactoryBot/FactoryClassName:
   Enabled: true
 
 RSpec/Rails/HttpStatus:

--- a/stree-compat.yml
+++ b/stree-compat.yml
@@ -9,6 +9,7 @@ inherit_from:
 
 AllCops:
   TargetRubyVersion: 3.2
+  SuggestExtensions: false
   DisabledByDefault: true
   Exclude:
     - 'db/schema.rb'

--- a/stree-compat.yml
+++ b/stree-compat.yml
@@ -3,6 +3,8 @@ require:
 
 inherit_from:
   - ./rubocop-core.yml
+  - ./rubocop-capybara.yml
+  - ./rubocop-factory_bot.yml
   - ./rubocop-rspec.yml
 
 AllCops:


### PR DESCRIPTION
### What is this change?

RuboCop RSpec used to contain departments for Capybara and FactoryBot cops, but those are being split out into `rubocop-capybara` and `rubocop-factory_bot` gems respectively. This change updates our gemspec and configuration files to reflect that.

It also silences the extension suggestion that otherwise shows up after each run, e.g.:

```
Tip: Based on detected gems, the following RuboCop extension libraries might be helpful:
  * rubocop-rake (https://rubygems.org/gems/rubocop-rake)
```