### PR TITLE
DEV: Enable some cops related to RSpec subject

### DIFF
--- a/rubocop-discourse.gemspec
+++ b/rubocop-discourse.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name = "rubocop-discourse"
-  s.version = "3.2.0"
+  s.version = "3.3.0"
   s.summary = "Custom rubocop cops used by Discourse"
   s.authors = ["Discourse Team"]
   s.license = "MIT"

--- a/rubocop-rspec.yml
+++ b/rubocop-rspec.yml
@@ -73,7 +73,7 @@ RSpec/EmptyLineAfterHook:
   Enabled: false # TODO
 
 RSpec/EmptyLineAfterSubject:
-  Enabled: false # TODO
+  Enabled: true
 
 RSpec/ExampleLength:
   Enabled: false # To be decided
@@ -130,7 +130,7 @@ RSpec/IteratedExpectation:
   Enabled: false # To be decided
 
 RSpec/LeadingSubject:
-  Enabled: false # TODO
+  Enabled: true
 
 RSpec/LeakyConstantDeclaration:
   Enabled: false # To be decided
@@ -157,7 +157,7 @@ RSpec/MultipleSubjects:
   Enabled: true
 
 RSpec/NamedSubject:
-  Enabled: false # To be decided
+  Enabled: true
 
 RSpec/NestedGroups:
   Enabled: false # To be decided

--- a/spec/lib/rubocop/cop/no_add_reference_active_record_migrations_spec.rb
+++ b/spec/lib/rubocop/cop/no_add_reference_active_record_migrations_spec.rb
@@ -5,20 +5,21 @@ require "spec_helper"
 describe RuboCop::Cop::Discourse::NoAddReferenceOrAliasesActiveRecordMigration,
          :config do
   subject(:cop) { described_class.new(config) }
+
   let(:config) { RuboCop::Config.new }
 
   it "raises an offense if add_reference is used, with or without arguments" do
     inspect_source(<<~RUBY)
       add_reference :posts, :users, foreign_key: true, null: false
     RUBY
-    expect(cop.offenses.first.message).to eq(described_class::MSG)
+    expect(cop.offenses.first.message).to match(described_class::MSG)
   end
 
   it "raises an offense if add_belongs_to is used, with or without arguments" do
     inspect_source(<<~RUBY)
       add_belongs_to :posts, :users, foreign_key: true, null: false
     RUBY
-    expect(cop.offenses.first.message).to eq(described_class::MSG)
+    expect(cop.offenses.first.message).to match(described_class::MSG)
   end
 
   it "raises an offense if t.references, or any variable.references is used, with or without arguments" do
@@ -31,7 +32,7 @@ describe RuboCop::Cop::Discourse::NoAddReferenceOrAliasesActiveRecordMigration,
       end
     RUBY
     expect(cop.offenses.count).to eq(2)
-    expect(cop.offenses.first.message).to eq(described_class::MSG)
+    expect(cop.offenses.first.message).to match(described_class::MSG)
   end
 
   it "raises an offense if t.belongs_to, or any variable.belongs_to is used, with or without arguments" do
@@ -44,6 +45,6 @@ describe RuboCop::Cop::Discourse::NoAddReferenceOrAliasesActiveRecordMigration,
       end
     RUBY
     expect(cop.offenses.count).to eq(2)
-    expect(cop.offenses.first.message).to eq(described_class::MSG)
+    expect(cop.offenses.first.message).to match(described_class::MSG)
   end
 end

--- a/spec/lib/rubocop/cop/no_mixing_multisite_and_standard_specs_spec.rb
+++ b/spec/lib/rubocop/cop/no_mixing_multisite_and_standard_specs_spec.rb
@@ -16,7 +16,7 @@ describe RuboCop::Cop::Discourse::NoMixingMultisiteAndStandardSpecs, :config do
       end
     RUBY
 
-    expect(cop.offenses.first.message).to eq(described_class::MSG)
+    expect(cop.offenses.first.message).to match(described_class::MSG)
   end
 
   it "raises an offense if there are multiple multisite and standard top-level describes" do
@@ -31,7 +31,7 @@ describe RuboCop::Cop::Discourse::NoMixingMultisiteAndStandardSpecs, :config do
       end
     RUBY
 
-    expect(cop.offenses.first.message).to eq(described_class::MSG)
+    expect(cop.offenses.first.message).to match(described_class::MSG)
   end
 
   it "does not raise an offense if there are only multisite describes" do

--- a/spec/lib/rubocop/cop/no_mocking_jobs_enqueue_spec.rb
+++ b/spec/lib/rubocop/cop/no_mocking_jobs_enqueue_spec.rb
@@ -12,7 +12,7 @@ describe RuboCop::Cop::Discourse::NoMockingJobs, :config do
     Jobs.expects(:enqueue)
     RUBY
 
-    expect(cop.offenses.first.message).to eq(described_class::MSG)
+    expect(cop.offenses.first.message).to end_with(described_class::MSG)
   end
 
   it "raises an offense if Jobs is mocked with :enqueue_in" do
@@ -20,7 +20,7 @@ describe RuboCop::Cop::Discourse::NoMockingJobs, :config do
     Jobs.expects(:enqueue_in)
     RUBY
 
-    expect(cop.offenses.first.message).to eq(described_class::MSG)
+    expect(cop.offenses.first.message).to end_with(described_class::MSG)
   end
 
   it "does not raise an offense if Jobs is not mocked with :enqueue or :enqueue_in" do

--- a/spec/lib/rubocop/cop/no_reset_column_information_migrations_spec.rb
+++ b/spec/lib/rubocop/cop/no_reset_column_information_migrations_spec.rb
@@ -8,6 +8,8 @@ describe RuboCop::Cop::Discourse::NoResetColumnInformationInMigrations,
 
   let(:config) { RuboCop::Config.new }
 
+  before { config["Discourse/NoResetColumnInformationInMigrations"]["Enabled"] = true }
+
   it "raises an offense if reset_column_information is used" do
     inspect_source(<<~RUBY)
       class SomeMigration < ActiveRecord::Migration[6.0]
@@ -17,7 +19,7 @@ describe RuboCop::Cop::Discourse::NoResetColumnInformationInMigrations,
       end
     RUBY
 
-    expect(cop.offenses.first.message).to eq(described_class::MSG)
+    expect(cop.offenses.first.message).to match(described_class::MSG)
   end
 
   it "raise an offense if reset_column_information is used without AR model" do
@@ -29,6 +31,6 @@ describe RuboCop::Cop::Discourse::NoResetColumnInformationInMigrations,
       end
     RUBY
 
-    expect(cop.offenses.first.message).to eq(described_class::MSG)
+    expect(cop.offenses.first.message).to match(described_class::MSG)
   end
 end

--- a/spec/lib/rubocop/cop/only_top_level_multisite_specs_spec.rb
+++ b/spec/lib/rubocop/cop/only_top_level_multisite_specs_spec.rb
@@ -15,7 +15,7 @@ describe RuboCop::Cop::Discourse::OnlyTopLevelMultisiteSpecs, :config do
       end
     RUBY
 
-    expect(cop.offenses.first.message).to eq(described_class::MSG)
+    expect(cop.offenses.first.message).to match(described_class::MSG)
   end
 
   it "raises an offense if multisite config option is used in a sub-describe (RSpec const version)" do
@@ -26,7 +26,7 @@ describe RuboCop::Cop::Discourse::OnlyTopLevelMultisiteSpecs, :config do
       end
     RUBY
 
-    expect(cop.offenses.first.message).to eq(described_class::MSG)
+    expect(cop.offenses.first.message).to match(described_class::MSG)
   end
 
   it "raises an offense if multisite config option is used in an example" do
@@ -40,7 +40,7 @@ describe RuboCop::Cop::Discourse::OnlyTopLevelMultisiteSpecs, :config do
       end
     RUBY
 
-    expect(cop.offenses.first.message).to eq(described_class::MSG)
+    expect(cop.offenses.first.message).to match(described_class::MSG)
   end
 
   it "raises an offense if multisite config option is used in a context" do
@@ -51,7 +51,7 @@ describe RuboCop::Cop::Discourse::OnlyTopLevelMultisiteSpecs, :config do
       end
     RUBY
 
-    expect(cop.offenses.first.message).to eq(described_class::MSG)
+    expect(cop.offenses.first.message).to match(described_class::MSG)
   end
 
   it "does not raise an offense if multisite config option is used on top-level describe" do

--- a/spec/lib/rubocop/cop/time_eq_matcher_spec.rb
+++ b/spec/lib/rubocop/cop/time_eq_matcher_spec.rb
@@ -12,7 +12,7 @@ describe RuboCop::Cop::Discourse::TimeEqMatcher, :config do
     expect(user.created_at).to eq(Time.zone.now)
     RUBY
 
-    expect(cop.offenses.first.message).to eq(described_class::MSG)
+    expect(cop.offenses.first.message).to match(described_class::MSG)
   end
 
   it "passes if a timestamp is compared using `eq_time`" do


### PR DESCRIPTION
This PR enables these cops:

- `RSpec/LeadingSubject`
- `RSpec/EmptyLineAfterSubject`
- `RSpec/NamedSubject`