### PR TITLE
DEV: Update FactoryBot rule names

### DIFF
--- a/rubocop-rspec.yml
+++ b/rubocop-rspec.yml
@@ -219,13 +219,13 @@ Capybara/CurrentPathExpectation:
 RSpec/Capybara/FeatureMethods:
   Enabled: true
 
-RSpec/FactoryBot/AttributeDefinedStatically:
+FactoryBot/AttributeDefinedStatically:
   Enabled: true
 
-RSpec/FactoryBot/CreateList:
+FactoryBot/CreateList:
   Enabled: true
 
-RSpec/FactoryBot/FactoryClassName:
+FactoryBot/FactoryClassName:
   Enabled: true
 
 RSpec/Rails/HttpStatus:


### PR DESCRIPTION
Those were moved in rubocop-rspec 2.22.0 (see: https://github.com/rubocop/rubocop-rspec/pull/1583)