### PR TITLE
DEV: Remove obsolete cop

### DIFF
--- a/rubocop-rspec.yml
+++ b/rubocop-rspec.yml
@@ -96,7 +96,10 @@ RSpec/ExpectInHook:
 RSpec/ExpectOutput:
   Enabled: true
 
-RSpec/FilePath:
+RSpec/SpecFilePathFormat:
+  Enabled: false # To be decided
+
+RSpec/SpecFilePathSuffix:
   Enabled: false # To be decided
 
 RSpec/Focus:


### PR DESCRIPTION
```
Error: The `RSpec/FilePath` cop has been split into `RSpec/SpecFilePathFormat` and `RSpec/SpecFilePathSuffix`.
(obsolete configuration found in vendor/bundle/ruby/3.0.0/gems/rubocop-discourse-3.3.0/rubocop-rspec.yml, please update it)
```

Removed in [rubocop-rspec 2.24.0](https://github.com/rubocop/rubocop-rspec/blob/master/CHANGELOG.md#2240-2023-09-08)