### PR TITLE
FIX: Disable autofix for BooleanSymbol

### DIFF
--- a/rubocop-core.yml
+++ b/rubocop-core.yml
@@ -90,6 +90,7 @@ Lint/RedundantStringCoercion:
 
 Lint/BooleanSymbol:
   Enabled: true
+  AutoCorrect: false # it breaks the code
 
 Lint/ShadowedArgument:
   Enabled: true

--- a/rubocop-discourse.gemspec
+++ b/rubocop-discourse.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name = "rubocop-discourse"
-  s.version = "3.5.0"
+  s.version = "3.5.1"
   s.summary = "Custom rubocop cops used by Discourse"
   s.authors = ["Discourse Team"]
   s.license = "MIT"


### PR DESCRIPTION
You can't just replace `:true`/`:false` with `true`/`false` and expect it to work the same 😅