### PR TITLE
DEV: enable Layout/EmptyLineBetweenDefs cop

### DIFF
--- a/rubocop-discourse.gemspec
+++ b/rubocop-discourse.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name = "rubocop-discourse"
-  s.version = "3.5.1"
+  s.version = "3.6.0"
   s.summary = "Custom rubocop cops used by Discourse"
   s.authors = ["Discourse Team"]
   s.license = "MIT"

--- a/rubocop-layout.yml
+++ b/rubocop-layout.yml
@@ -10,6 +10,10 @@ Layout/CommentIndentation:
 Layout/EmptyLines:
   Enabled: true
 
+# Use empty lines between definitions.
+Layout/EmptyLineBetweenDefs:
+  Enabled: true
+
 # Two spaces, no tabs (for indentation).
 Layout/IndentationWidth:
   Enabled: true


### PR DESCRIPTION
This has come up in some PR reviews previously. Docs: https://www.rubydoc.info/github/bbatsov/RuboCop/RuboCop/Cop/Layout/EmptyLineBetweenDefs

What the changes would look like: https://github.com/discourse/discourse/pull/24914.