### PR TITLE
Enable Lint/OrAssignmentToConstant

### DIFF
--- a/rubocop-core.yml
+++ b/rubocop-core.yml
@@ -140,3 +140,6 @@ Lint/EmptyConditionalBody:
 
 Lint/SafeNavigationConsistency:
   Enabled: true
+
+Lint/OrAssignmentToConstant:
+  Enabled: true

--- a/rubocop-discourse.gemspec
+++ b/rubocop-discourse.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name = "rubocop-discourse"
-  s.version = "3.8.3"
+  s.version = "3.8.4"
   s.summary = "Custom rubocop cops used by Discourse"
   s.authors = ["Discourse Team"]
   s.license = "MIT"


### PR DESCRIPTION
> [Constants should always be assigned in the same location. And its value should always be the same. If constants are assigned in multiple locations, the result may vary depending on the order of require.](https://docs.rubocop.org/rubocop/cops_lint.html#lintorassignmenttoconstant)
