### PR TITLE
DEV: Stop inheriting from deprecated Rubocop::Cop::Cop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.2'
+          ruby-version: "3.3"
           bundler-cache: true
 
       - name: Rubocop

--- a/lib/rubocop/cop/discourse/no_add_reference_active_record_migrations.rb
+++ b/lib/rubocop/cop/discourse/no_add_reference_active_record_migrations.rb
@@ -44,7 +44,7 @@ module RuboCop
       #     index_posts_on_image_upload_id ON posts USING btree (image_upload_id)
       #   SQL
       # end
-      class NoAddReferenceOrAliasesActiveRecordMigration < Cop
+      class NoAddReferenceOrAliasesActiveRecordMigration < Base
         MSG = <<~MSG
           AR methods add_reference, add_belongs_to, t.references, and t.belongs_to are
           high-risk for large tables and have too many background magic operations.
@@ -74,7 +74,7 @@ module RuboCop
                using_add_reference?(node),
                using_add_belongs_to?(node),
                using_t_references?(node),
-               using_t_belongs_to?(node)
+               using_t_belongs_to?(node),
              ].none?
             return
           end

--- a/lib/rubocop/cop/discourse/no_chdir.rb
+++ b/lib/rubocop/cop/discourse/no_chdir.rb
@@ -13,7 +13,7 @@ module RuboCop
       # @example
       #   # bad
       #   Dir.chdir("test")
-      class NoChdir < Cop
+      class NoChdir < Base
         MSG = "Chdir is not thread safe."
 
         def_node_matcher :using_dir_chdir?, <<-MATCHER

--- a/lib/rubocop/cop/discourse/no_direct_multisite_manipulation.rb
+++ b/lib/rubocop/cop/discourse/no_direct_multisite_manipulation.rb
@@ -16,7 +16,7 @@ module RuboCop
       #   it "works", type: :multisite do
       #     do_something
       #   end
-      class NoDirectMultisiteManipulation < Cop
+      class NoDirectMultisiteManipulation < Base
         MSG =
           "Use `type: :multisite` example setting instead of modifying `Rails.configuration.multisite`."
 

--- a/lib/rubocop/cop/discourse/no_json_parse_response.rb
+++ b/lib/rubocop/cop/discourse/no_json_parse_response.rb
@@ -11,9 +11,8 @@ module RuboCop
       #
       #   # good
       #   expect(response.parsed_body).to eq({})
-      class NoJsonParseResponse < Cop
-        MSG =
-          "Use `response.parsed_body` instead of `JSON.parse(response.body)` in specs."
+      class NoJsonParseResponse < Base
+        MSG = "Use `response.parsed_body` instead of `JSON.parse(response.body)` in specs."
 
         def_node_matcher :json_parse_body?, <<-MATCHER
           (send
@@ -29,9 +28,7 @@ module RuboCop
         end
 
         def autocorrect(node)
-          lambda do |corrector|
-            corrector.replace(node.loc.expression, "response.parsed_body")
-          end
+          lambda { |corrector| corrector.replace(node.loc.expression, "response.parsed_body") }
         end
       end
     end

--- a/lib/rubocop/cop/discourse/no_mixing_multisite_and_standard_specs.rb
+++ b/lib/rubocop/cop/discourse/no_mixing_multisite_and_standard_specs.rb
@@ -23,7 +23,7 @@ module RuboCop
       #   # x_multisite_spec.rb
       #   describe "x", type: :multisite do
       #   end
-      class NoMixingMultisiteAndStandardSpecs < Cop
+      class NoMixingMultisiteAndStandardSpecs < Base
         MSG =
           "Do not mix multisite and standard specs. Consider moving multisite describes to a separate file."
 

--- a/lib/rubocop/cop/discourse/no_mocking_jobs.rb
+++ b/lib/rubocop/cop/discourse/no_mocking_jobs.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Discourse
-      class NoMockingJobs < Cop
+      class NoMockingJobs < Base
         MSG =
           "Use the test helpers provided by Sidekiq instead of mocking `Jobs.expects(:enqueue)`."
 

--- a/lib/rubocop/cop/discourse/no_nokogiri_html_fragment.rb
+++ b/lib/rubocop/cop/discourse/no_nokogiri_html_fragment.rb
@@ -12,7 +12,7 @@ module RuboCop
       #
       #   # good
       #   Nokogiri::HTML5.fragment("<p>test</p>")
-      class NoNokogiriHtmlFragment < Cop
+      class NoNokogiriHtmlFragment < Base
         MSG = "Nokogiri::HTML.fragment is deprecated and should not be used."
 
         def_node_matcher :using_nokogiri_html_fragment?, <<-MATCHER

--- a/lib/rubocop/cop/discourse/no_reset_column_information_in_migrations.rb
+++ b/lib/rubocop/cop/discourse/no_reset_column_information_in_migrations.rb
@@ -7,7 +7,7 @@ module RuboCop
       # migrations. The method is not thread safe and we run migrations
       # concurrently for multisites. Also, we don't encourage the use of
       # ActiveRecord methods in migrations and prefer to write SQL directly.
-      class NoResetColumnInformationInMigrations < Cop
+      class NoResetColumnInformationInMigrations < Base
         MSG =
           "ActiveRecord::ModelSchema.reset_column_information is not thread-safe " \
             "and we run migrations concurrently on multisite clusters. Using this " \

--- a/lib/rubocop/cop/discourse/no_time_new_without_args.rb
+++ b/lib/rubocop/cop/discourse/no_time_new_without_args.rb
@@ -11,7 +11,7 @@ module RuboCop
       #
       #   # good
       #   now = Time.zone.now
-      class NoTimeNewWithoutArgs < Cop
+      class NoTimeNewWithoutArgs < Base
         MSG = "Use `Time.zone.now` instead of `Time.new` without arguments."
 
         def_node_matcher :time_new_without_args?, <<-MATCHER
@@ -25,9 +25,7 @@ module RuboCop
         end
 
         def autocorrect(node)
-          lambda do |corrector|
-            corrector.replace(node.loc.expression, "Time.zone.now")
-          end
+          lambda { |corrector| corrector.replace(node.loc.expression, "Time.zone.now") }
         end
       end
     end

--- a/lib/rubocop/cop/discourse/no_uri_escape_encode.rb
+++ b/lib/rubocop/cop/discourse/no_uri_escape_encode.rb
@@ -15,7 +15,7 @@ module RuboCop
       #   # good
       #   UrlHelper.encode("https://a%20a.com?a='a%22")
       #   Addressable::URI.encode("https://a%20a.com?a='a%22")
-      class NoURIEscapeEncode < Cop
+      class NoURIEscapeEncode < Base
         MSG =
           "URI.escape, URI.encode, URI.unescape, URI.decode are deprecated and should not be used."
 
@@ -40,7 +40,7 @@ module RuboCop
                using_uri_escape?(node),
                using_uri_encode?(node),
                using_uri_unescape?(node),
-               using_uri_decode?(node)
+               using_uri_decode?(node),
              ].none?
             return
           end

--- a/lib/rubocop/cop/discourse/only_top_level_multisite_specs.rb
+++ b/lib/rubocop/cop/discourse/only_top_level_multisite_specs.rb
@@ -25,7 +25,7 @@ module RuboCop
       #     it "does X" do
       #     end
       #   end
-      class OnlyTopLevelMultisiteSpecs < Cop
+      class OnlyTopLevelMultisiteSpecs < Base
         MSG = "Use `type: :multisite` only on a top-level `describe`"
 
         def on_block(node)

--- a/lib/rubocop/cop/discourse/time_eq_matcher.rb
+++ b/lib/rubocop/cop/discourse/time_eq_matcher.rb
@@ -11,7 +11,7 @@ module RuboCop
       #
       #   # good
       #   expect(user.created_at).to eq_time(Time.zone.now)
-      class TimeEqMatcher < Cop
+      class TimeEqMatcher < Base
         MSG = "Use eq_time when testing timestamps"
 
         def_node_matcher :using_eq_matcher_with_timestamp?, <<-MATCHER
@@ -29,9 +29,7 @@ module RuboCop
         end
 
         def autocorrect(node)
-          lambda do |corrector|
-            corrector.replace(node.children.last.loc.selector, "eq_time")
-          end
+          lambda { |corrector| corrector.replace(node.children.last.loc.selector, "eq_time") }
         end
 
         private

--- a/rubocop-discourse.gemspec
+++ b/rubocop-discourse.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name = "rubocop-discourse"
-  s.version = "3.8.1"
+  s.version = "3.8.2"
   s.summary = "Custom rubocop cops used by Discourse"
   s.authors = ["Discourse Team"]
   s.license = "MIT"

--- a/spec/lib/rubocop/cop/no_add_reference_active_record_migrations_spec.rb
+++ b/spec/lib/rubocop/cop/no_add_reference_active_record_migrations_spec.rb
@@ -2,28 +2,27 @@
 
 require "spec_helper"
 
-describe RuboCop::Cop::Discourse::NoAddReferenceOrAliasesActiveRecordMigration,
-         :config do
+describe RuboCop::Cop::Discourse::NoAddReferenceOrAliasesActiveRecordMigration, :config do
   subject(:cop) { described_class.new(config) }
 
   let(:config) { RuboCop::Config.new }
 
   it "raises an offense if add_reference is used, with or without arguments" do
-    inspect_source(<<~RUBY)
+    offenses = inspect_source(<<~RUBY)
       add_reference :posts, :users, foreign_key: true, null: false
     RUBY
-    expect(cop.offenses.first.message).to match(described_class::MSG)
+    expect(offenses.first.message).to match(described_class::MSG)
   end
 
   it "raises an offense if add_belongs_to is used, with or without arguments" do
-    inspect_source(<<~RUBY)
+    offenses = inspect_source(<<~RUBY)
       add_belongs_to :posts, :users, foreign_key: true, null: false
     RUBY
-    expect(cop.offenses.first.message).to match(described_class::MSG)
+    expect(offenses.first.message).to match(described_class::MSG)
   end
 
   it "raises an offense if t.references, or any variable.references is used, with or without arguments" do
-    inspect_source(<<~RUBY)
+    offenses = inspect_source(<<~RUBY)
       create_table do |t|
         t.references :topic, null: false
       end
@@ -31,12 +30,12 @@ describe RuboCop::Cop::Discourse::NoAddReferenceOrAliasesActiveRecordMigration,
         mytable.references :topic, null: false
       end
     RUBY
-    expect(cop.offenses.count).to eq(2)
-    expect(cop.offenses.first.message).to match(described_class::MSG)
+    expect(offenses.count).to eq(2)
+    expect(offenses.first.message).to match(described_class::MSG)
   end
 
   it "raises an offense if t.belongs_to, or any variable.belongs_to is used, with or without arguments" do
-    inspect_source(<<~RUBY)
+    offenses = inspect_source(<<~RUBY)
       create_table do |t|
         t.belongs_to :topic, null: false
       end
@@ -44,7 +43,7 @@ describe RuboCop::Cop::Discourse::NoAddReferenceOrAliasesActiveRecordMigration,
         mytable.belongs_to :topic, null: false
       end
     RUBY
-    expect(cop.offenses.count).to eq(2)
-    expect(cop.offenses.first.message).to match(described_class::MSG)
+    expect(offenses.count).to eq(2)
+    expect(offenses.first.message).to match(described_class::MSG)
   end
 end

--- a/spec/lib/rubocop/cop/no_mixing_multisite_and_standard_specs_spec.rb
+++ b/spec/lib/rubocop/cop/no_mixing_multisite_and_standard_specs_spec.rb
@@ -8,7 +8,7 @@ describe RuboCop::Cop::Discourse::NoMixingMultisiteAndStandardSpecs, :config do
   let(:config) { RuboCop::Config.new }
 
   it "raises an offense if there are multisite and standard top-level describes" do
-    inspect_source(<<~RUBY)
+    offenses = inspect_source(<<~RUBY)
       RSpec.describe "test" do
       end
 
@@ -16,11 +16,11 @@ describe RuboCop::Cop::Discourse::NoMixingMultisiteAndStandardSpecs, :config do
       end
     RUBY
 
-    expect(cop.offenses.first.message).to match(described_class::MSG)
+    expect(offenses.first.message).to match(described_class::MSG)
   end
 
   it "raises an offense if there are multiple multisite and standard top-level describes" do
-    inspect_source(<<~RUBY)
+    offenses = inspect_source(<<~RUBY)
       describe "test", type: :multisite do
       end
 
@@ -31,11 +31,11 @@ describe RuboCop::Cop::Discourse::NoMixingMultisiteAndStandardSpecs, :config do
       end
     RUBY
 
-    expect(cop.offenses.first.message).to match(described_class::MSG)
+    expect(offenses.first.message).to match(described_class::MSG)
   end
 
   it "does not raise an offense if there are only multisite describes" do
-    inspect_source(<<~RUBY)
+    offenses = inspect_source(<<~RUBY)
       require "foo"
 
       describe "test", type: :multisite do
@@ -49,11 +49,11 @@ describe RuboCop::Cop::Discourse::NoMixingMultisiteAndStandardSpecs, :config do
       end
     RUBY
 
-    expect(cop.offenses).to eq([])
+    expect(offenses).to eq([])
   end
 
   it "does not raise an offense if there are only standard describes" do
-    inspect_source(<<~RUBY)
+    offenses = inspect_source(<<~RUBY)
       require "rails_helper"
 
       describe "test" do
@@ -65,6 +65,6 @@ describe RuboCop::Cop::Discourse::NoMixingMultisiteAndStandardSpecs, :config do
       end
     RUBY
 
-    expect(cop.offenses).to eq([])
+    expect(offenses).to eq([])
   end
 end

--- a/spec/lib/rubocop/cop/no_mocking_jobs_enqueue_spec.rb
+++ b/spec/lib/rubocop/cop/no_mocking_jobs_enqueue_spec.rb
@@ -8,26 +8,26 @@ describe RuboCop::Cop::Discourse::NoMockingJobs, :config do
   let(:config) { RuboCop::Config.new }
 
   it "raises an offense if Jobs is mocked with :enqueue" do
-    inspect_source(<<~RUBY)
+    offenses = inspect_source(<<~RUBY)
     Jobs.expects(:enqueue)
     RUBY
 
-    expect(cop.offenses.first.message).to end_with(described_class::MSG)
+    expect(offenses.first.message).to end_with(described_class::MSG)
   end
 
   it "raises an offense if Jobs is mocked with :enqueue_in" do
-    inspect_source(<<~RUBY)
+    offenses = inspect_source(<<~RUBY)
     Jobs.expects(:enqueue_in)
     RUBY
 
-    expect(cop.offenses.first.message).to end_with(described_class::MSG)
+    expect(offenses.first.message).to end_with(described_class::MSG)
   end
 
   it "does not raise an offense if Jobs is not mocked with :enqueue or :enqueue_in" do
-    inspect_source(<<~RUBY)
+    offenses = inspect_source(<<~RUBY)
     Jobs.enqueue(:some_job)
     RUBY
 
-    expect(cop.offenses).to eq([])
+    expect(offenses).to eq([])
   end
 end

--- a/spec/lib/rubocop/cop/no_reset_column_information_migrations_spec.rb
+++ b/spec/lib/rubocop/cop/no_reset_column_information_migrations_spec.rb
@@ -2,8 +2,7 @@
 
 require "spec_helper"
 
-describe RuboCop::Cop::Discourse::NoResetColumnInformationInMigrations,
-         :config do
+describe RuboCop::Cop::Discourse::NoResetColumnInformationInMigrations, :config do
   subject(:cop) { described_class.new(config) }
 
   let(:config) { RuboCop::Config.new }
@@ -11,7 +10,7 @@ describe RuboCop::Cop::Discourse::NoResetColumnInformationInMigrations,
   before { config["Discourse/NoResetColumnInformationInMigrations"]["Enabled"] = true }
 
   it "raises an offense if reset_column_information is used" do
-    inspect_source(<<~RUBY)
+    offenses = inspect_source(<<~RUBY)
       class SomeMigration < ActiveRecord::Migration[6.0]
         def up
           Post.reset_column_information
@@ -19,11 +18,11 @@ describe RuboCop::Cop::Discourse::NoResetColumnInformationInMigrations,
       end
     RUBY
 
-    expect(cop.offenses.first.message).to match(described_class::MSG)
+    expect(offenses.first.message).to match(described_class::MSG)
   end
 
   it "raise an offense if reset_column_information is used without AR model" do
-    inspect_source(<<~RUBY)
+    offenses = inspect_source(<<~RUBY)
       class SomeMigration < ActiveRecord::Migration[6.0]
         def up
           "post".classify.constantize.reset_column_information
@@ -31,6 +30,6 @@ describe RuboCop::Cop::Discourse::NoResetColumnInformationInMigrations,
       end
     RUBY
 
-    expect(cop.offenses.first.message).to match(described_class::MSG)
+    expect(offenses.first.message).to match(described_class::MSG)
   end
 end

--- a/spec/lib/rubocop/cop/only_top_level_multisite_specs_spec.rb
+++ b/spec/lib/rubocop/cop/only_top_level_multisite_specs_spec.rb
@@ -8,29 +8,29 @@ describe RuboCop::Cop::Discourse::OnlyTopLevelMultisiteSpecs, :config do
   let(:config) { RuboCop::Config.new }
 
   it "raises an offense if multisite config option is used in a sub-describe" do
-    inspect_source(<<~RUBY)
+    offenses = inspect_source(<<~RUBY)
       describe "test" do
         describe "sub-test", type: :multisite do
         end
       end
     RUBY
 
-    expect(cop.offenses.first.message).to match(described_class::MSG)
+    expect(offenses.first.message).to match(described_class::MSG)
   end
 
   it "raises an offense if multisite config option is used in a sub-describe (RSpec const version)" do
-    inspect_source(<<~RUBY)
+    offenses = inspect_source(<<~RUBY)
       RSpec.describe "test" do
         RSpec.describe "sub-test", type: :multisite do
         end
       end
     RUBY
 
-    expect(cop.offenses.first.message).to match(described_class::MSG)
+    expect(offenses.first.message).to match(described_class::MSG)
   end
 
   it "raises an offense if multisite config option is used in an example" do
-    inspect_source(<<~RUBY)
+    offenses = inspect_source(<<~RUBY)
       describe "test" do
         it "acts as an example" do
         end
@@ -40,33 +40,33 @@ describe RuboCop::Cop::Discourse::OnlyTopLevelMultisiteSpecs, :config do
       end
     RUBY
 
-    expect(cop.offenses.first.message).to match(described_class::MSG)
+    expect(offenses.first.message).to match(described_class::MSG)
   end
 
   it "raises an offense if multisite config option is used in a context" do
-    inspect_source(<<~RUBY)
+    offenses = inspect_source(<<~RUBY)
       describe "test" do
         context "special circumstances", type: :multisite do
         end
       end
     RUBY
 
-    expect(cop.offenses.first.message).to match(described_class::MSG)
+    expect(offenses.first.message).to match(described_class::MSG)
   end
 
   it "does not raise an offense if multisite config option is used on top-level describe" do
-    inspect_source(<<~RUBY)
+    offenses = inspect_source(<<~RUBY)
       describe "test", type: :multisite do
         describe "sub-test" do
         end
       end
     RUBY
 
-    expect(cop.offenses).to eq([])
+    expect(offenses).to eq([])
   end
 
   it "does not raise an offense if multisite config option is used on top-level describe (RSpec const version)" do
-    inspect_source(<<~RUBY)
+    offenses = inspect_source(<<~RUBY)
       require "rails_helper"
 
       RSpec.describe "test", type: :multisite do
@@ -75,6 +75,6 @@ describe RuboCop::Cop::Discourse::OnlyTopLevelMultisiteSpecs, :config do
       end
     RUBY
 
-    expect(cop.offenses).to eq([])
+    expect(offenses).to eq([])
   end
 end

--- a/spec/lib/rubocop/cop/time_eq_matcher_spec.rb
+++ b/spec/lib/rubocop/cop/time_eq_matcher_spec.rb
@@ -8,18 +8,18 @@ describe RuboCop::Cop::Discourse::TimeEqMatcher, :config do
   let(:config) { RuboCop::Config.new }
 
   it "raises an offense if a timestamp is compared using `eq`" do
-    inspect_source(<<~RUBY)
+    offenses = inspect_source(<<~RUBY)
     expect(user.created_at).to eq(Time.zone.now)
     RUBY
 
-    expect(cop.offenses.first.message).to match(described_class::MSG)
+    expect(offenses.first.message).to match(described_class::MSG)
   end
 
   it "passes if a timestamp is compared using `eq_time`" do
-    inspect_source(<<~RUBY)
+    offenses = inspect_source(<<~RUBY)
       expect(user.created_at).to eq_time(Time.zone.now)
     RUBY
 
-    expect(cop.offenses).to be_empty
+    expect(offenses).to be_empty
   end
 end


### PR DESCRIPTION
> warning: Inheriting from `RuboCop::Cop::Cop` is deprecated. Use `RuboCop::Cop::Base` instead.
