### PR TITLE
DEV: add Rails/ReversibleMigrationMethodDefinition cop

### DIFF
--- a/rubocop-discourse.gemspec
+++ b/rubocop-discourse.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name = "rubocop-discourse"
-  s.version = "3.8.2"
+  s.version = "3.8.3"
   s.summary = "Custom rubocop cops used by Discourse"
   s.authors = ["Discourse Team"]
   s.license = "MIT"

--- a/rubocop-rails.yml
+++ b/rubocop-rails.yml
@@ -9,3 +9,6 @@ Rails/EnumHash:
 
 Rails/EnumUniqueness:
   Enabled: true
+
+Rails/ReversibleMigrationMethodDefinition:
+  Enabled: true


### PR DESCRIPTION
We have some migrations that are executing code outside of reversible methods. This cop guards against that. 

I'll merge once all our core/plugins/themes have this resolved in separate PRs.