### PR TITLE
Enables Style/MutableConstant cop

### DIFF
--- a/rubocop-core.yml
+++ b/rubocop-core.yml
@@ -54,6 +54,9 @@ Style/UnlessElse:
 Style/UnlessLogicalOperators:
   Enabled: true
 
+Style/MutableConstant:
+  Enabled: true
+
 Lint/Debugger:
   Enabled: true
 

--- a/rubocop-discourse.gemspec
+++ b/rubocop-discourse.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name = "rubocop-discourse"
-  s.version = "3.8.4"
+  s.version = "3.8.5"
   s.summary = "Custom rubocop cops used by Discourse"
   s.authors = ["Discourse Team"]
   s.license = "MIT"


### PR DESCRIPTION
There is no reason we should allow a constant to be mutable.

See https://docs.rubocop.org/rubocop/cops_style.html#stylemutableconstant

This could have prevented a bug like https://github.com/discourse/discourse/commit/4840060568e8066ed19ed35eb81fb4bfb97fea88