### PR TITLE
DEV: Change cop to handle `fab!(:name) { Fabricate(:fabricator) }`

### DIFF
--- a/spec/lib/rubocop/cop/fabricator_shorthand_spec.rb
+++ b/spec/lib/rubocop/cop/fabricator_shorthand_spec.rb
@@ -22,15 +22,24 @@ RSpec.describe RuboCop::Cop::Discourse::FabricatorShorthand, :config do
     RUBY
   end
 
-  it "does not register an offense when the identifier doesn't match" do
-    expect_no_offenses(<<~RUBY)
+  it "registers an offense when the identifier doesn't match and can be simplified" do
+    expect_offense(<<~RUBY)
       RSpec.describe "Foo" do
         fab!(:bar) { Fabricate(:foo) }
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Discourse/FabricatorShorthand: Use the fabricator shorthand: `fab!(:bar, :foo)`
       end
     RUBY
   end
 
-  it "supports autocorrect" do
+  it "does not register an offense when the identifier doesn't match and the fabricator has attributes" do
+    expect_no_offenses(<<~RUBY)
+      RSpec.describe "Foo" do
+        fab!(:bar) { Fabricate(:foo, bar: 1) }
+      end
+    RUBY
+  end
+
+  it "supports autocorrect when the name and fabricator matches" do
     expect_offense(<<~RUBY)
       RSpec.describe "Foo" do
         fab!(:foo) { Fabricate(:foo) }
@@ -41,6 +50,21 @@ RSpec.describe RuboCop::Cop::Discourse::FabricatorShorthand, :config do
     expect_correction(<<~RUBY)
       RSpec.describe "Foo" do
         fab!(:foo)
+      end
+    RUBY
+  end
+
+  it "supports autocorrect when the name and fabricator don't match" do
+    expect_offense(<<~RUBY)
+      RSpec.describe "Foo" do
+        fab!(:bar) { Fabricate(:foo) }
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Discourse/FabricatorShorthand: Use the fabricator shorthand: `fab!(:bar, :foo)`
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      RSpec.describe "Foo" do
+        fab!(:bar, :foo)
       end
     RUBY
   end


### PR DESCRIPTION
Enhance the `FabricatorShorthand` cop to handle cases where variable and fabricator names differ without additional attributes.