### PR TITLE
DEV: Disable `Rails/WhereNot` rule

### DIFF
--- a/lib/rubocop/discourse/version.rb
+++ b/lib/rubocop/discourse/version.rb
@@ -2,6 +2,6 @@
 
 module RuboCop
   module Discourse
-    VERSION = "3.13.0"
+    VERSION = "3.13.1"
   end
 end

--- a/rubocop-rails.yml
+++ b/rubocop-rails.yml
@@ -98,8 +98,9 @@ Rails/UnusedRenderContent:
 Rails/WhereMissing:
   Enabled: true
 
+# NOTE: This is unsafe as the autofix breaks mini_sql code (that only looks like AR code)
 Rails/WhereNot:
-  Enabled: true
+  Enabled: false
 
 Rails/ActiveRecordCallbacksOrder:
   Enabled: true


### PR DESCRIPTION
…as it's unsafe, because the autofix breaks mini_sql code (that only looks like AR code)