### PR TITLE
DEV: Disable `Rails/WhereMissing` rule

### DIFF
--- a/lib/rubocop/discourse/version.rb
+++ b/lib/rubocop/discourse/version.rb
@@ -2,6 +2,6 @@
 
 module RuboCop
   module Discourse
-    VERSION = "3.13.1"
+    VERSION = "3.13.2"
   end
 end

--- a/rubocop-rails.yml
+++ b/rubocop-rails.yml
@@ -95,8 +95,9 @@ Rails/Validation:
 Rails/UnusedRenderContent:
   Enabled: true
 
+# NOTE: This is unsafe due to a Rails bug (https://github.com/rails/rails/issues/55130)
 Rails/WhereMissing:
-  Enabled: true
+  Enabled: false
 
 # NOTE: This is unsafe as the autofix breaks mini_sql code (that only looks like AR code)
 Rails/WhereNot:


### PR DESCRIPTION
…because it's unsafe due to a Rails bug