### PR TITLE
DEV: Disable `NotNilAndNotEmpty` option of `Rails/Present`

### DIFF
--- a/lib/rubocop/discourse/version.rb
+++ b/lib/rubocop/discourse/version.rb
@@ -2,6 +2,6 @@
 
 module RuboCop
   module Discourse
-    VERSION = "3.13.2"
+    VERSION = "3.13.3"
   end
 end

--- a/rubocop-rails.yml
+++ b/rubocop-rails.yml
@@ -58,6 +58,7 @@ Rails/Presence:
 
 Rails/Present:
   Enabled: true
+  NotNilAndNotEmpty: false # this one is based on an incorrect premise that empty? and blank? are equivalent
   Exclude:
     - "bin/*"
 


### PR DESCRIPTION
That one is based on an incorrect premise that `#empty?` and `#blank?` are equivalent