### PR TITLE
FEATURE: Add MutableAttributeDefault rule

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -94,3 +94,6 @@ Discourse/Services/GroupKeywords:
 
 Discourse/Services/EmptyLinesAroundBlocks:
   Enabled: true
+
+Discourse/Services/MutableAttributeDefault:
+  Enabled: true

--- a/lib/rubocop/cop/discourse/services/mutable_attribute_default.rb
+++ b/lib/rubocop/cop/discourse/services/mutable_attribute_default.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Discourse
+      module Services
+        # Wrap mutable `attribute` defaults in a proc — `ActiveModel::Attributes`
+        # shares the literal across instances, so mutations leak between calls.
+        # `:array`-typed attributes are exempt; the type dups on read.
+        #
+        # @example
+        #   # bad
+        #   options do
+        #   attribute :overrides, default: {}
+        #     attribute :ids, default: [1, 2]
+        #   end
+        #
+        #   # good
+        #   options do
+        #   attribute :overrides, default: -> { {} }
+        #     attribute :ids, default: -> { [1, 2] }
+        #     attribute :tags, :array, default: [] # :array dups per read
+        #   end
+        #
+        class MutableAttributeDefault < Base
+          extend AutoCorrector
+
+          MSG =
+            "Mutable `default: %<source>s` is shared across all instances; wrap it in a proc: `-> { %<source>s }`."
+          RESTRICT_ON_SEND = %i[attribute].freeze
+
+          def_node_matcher :service_include?, <<~MATCHER
+            (class _ _
+             {
+               (begin <(send nil? :include (const (const nil? :Service) :Base)) ...>)
+               <(send nil? :include (const (const nil? :Service) :Base)) ...>
+             }
+            )
+          MATCHER
+
+          def_node_matcher :mutable_default, <<~PATTERN
+            (send nil? :attribute _ ... (hash <(pair (sym :default) ${hash array}) ...>))
+          PATTERN
+
+          def_node_matcher :array_typed?, <<~PATTERN
+            (send nil? :attribute _ (sym :array) ...)
+          PATTERN
+
+          def on_class(node)
+            @service = true if service_include?(node)
+          end
+
+          def on_send(node)
+            return unless @service
+            return if array_typed?(node)
+            default = mutable_default(node)
+            return unless default
+
+            source = default.source
+            add_offense(default, message: format(MSG, source: source)) do |corrector|
+              corrector.replace(default, "-> { #{source} }")
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/discourse/version.rb
+++ b/lib/rubocop/discourse/version.rb
@@ -2,6 +2,6 @@
 
 module RuboCop
   module Discourse
-    VERSION = "3.16.0"
+    VERSION = "3.17.0"
   end
 end

--- a/spec/lib/rubocop/cop/discourse/services/mutable_attribute_default_spec.rb
+++ b/spec/lib/rubocop/cop/discourse/services/mutable_attribute_default_spec.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Discourse::Services::MutableAttributeDefault, :config do
+  subject(:cop) { described_class.new(config) }
+
+  let(:config) { RuboCop::Config.new }
+
+  context "when not in a service class" do
+    it "does nothing" do
+      expect_no_offenses(<<~RUBY)
+        class NotAService
+          attribute :foo, default: {}
+          attribute :bar, default: []
+        end
+      RUBY
+    end
+  end
+
+  context "when in a service class" do
+    context "with a hash literal default" do
+      it "registers an offense" do
+        expect_offense(<<~RUBY)
+          class MyService
+            include Service::Base
+
+            options do
+              attribute :overrides, default: {}
+                                             ^^ Discourse/Services/MutableAttributeDefault: Mutable `default: {}` is shared across all instances; wrap it in a proc: `-> { {} }`.
+            end
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          class MyService
+            include Service::Base
+
+            options do
+              attribute :overrides, default: -> { {} }
+            end
+          end
+        RUBY
+      end
+    end
+
+    context "with an array literal default and no type" do
+      it "registers an offense" do
+        expect_offense(<<~RUBY)
+          class MyService
+            include Service::Base
+
+            options do
+              attribute :ids, default: [1, 2]
+                                       ^^^^^^ Discourse/Services/MutableAttributeDefault: Mutable `default: [1, 2]` is shared across all instances; wrap it in a proc: `-> { [1, 2] }`.
+            end
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          class MyService
+            include Service::Base
+
+            options do
+              attribute :ids, default: -> { [1, 2] }
+            end
+          end
+        RUBY
+      end
+    end
+
+    context "with `:array` cast type and an array default" do
+      it "does not register an offense" do
+        expect_no_offenses(<<~RUBY)
+          class MyService
+            include Service::Base
+
+            options do
+              attribute :tags, :array, default: []
+              attribute :seeds, :array, default: [1, 2]
+            end
+          end
+        RUBY
+      end
+    end
+
+    context "without a default kwarg" do
+      it "does not register an offense" do
+        expect_no_offenses(<<~RUBY)
+          class MyService
+            include Service::Base
+
+            params do
+              attribute :foo
+              attribute :bar, :string
+            end
+          end
+        RUBY
+      end
+    end
+  end
+end


### PR DESCRIPTION
Flags `attribute :foo, default: {}` / `default: []` in service classes to avoid leaking.